### PR TITLE
Add feature support for newer PBIS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,11 @@ and place them in the module's `files/` folder.
 
 For scalability, or if you are using variable module paths, you may want to add the PBIS Open packages to a local `apt` or `yum` repository.
 
-In that case, include the class with `use_repository => true`.
-
-    node 'workstation' {
-      class { 'pbis':
-        ...
-        use_repository => true,
-      }
-    }
+In that case, sync with the [BeyondTrust Public Repo](https://repo.pbis.beyondtrust.com), and set $yum_install => true (the default)
 
 ### Service name change.
 
-The service name may not be 'lsass' on newer version of PBIS and may be 'lwsmd'. This is now configurable as below:
+The service name was changed from 'lsass' to 'lwsmd' in Likewise Open 6.0, and therefore all versions of PBIS. This is now configurable as below:
 
     node 'workstation' {
       class { 'pbis':
@@ -67,12 +60,13 @@ The service name may not be 'lsass' on newer version of PBIS and may be 'lwsmd'.
 ## Dependencies
 
 This module requires the `osfamily` fact, which depends on Facter 1.6.1+.
+This module requires the 'wget' module, which you can get via: `puppet module install maestrodev-wget --version 1.7.3`
 
 ## Supported platforms
 
 This module has been tested against Puppet 2.7.18+ and Facter 1.6.9+ on Debian 7 and Ubuntu 12.04.
 
-Support for RedHat and Suse is included but has not been tested.
+Support for RedHat and Suse is included and has been tested 2016-11-16.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Joins a node to an Active Directory domain using PowerBroker Identity Services O
         ou                    => 'ou=Computers,ou=Department,ou=Divison',
         user_domain_prefix    => 'ADS',
         require_membership_of => 'ADS\\Linux_Users',
+        version               => "8.5.1-206"
       }
     }
 
@@ -24,7 +25,8 @@ This module supports two ways of distributing the PBIS Open packages:
 
 The default is to use Puppet's built-in fileserver.
 
-In either case, download the necessary packages from the [BeyondTrust website](http://www.beyondtrust.com/Technical-Support/Downloads/PowerBroker-Identity-Services-Open-Edition/?Pass=True). Extract the architecture-specific `pbis-open` `.rpm` or `.deb` file from the self-extracting `sh` archive.
+In either case, download the necessary packages from the [BeyondTrust Repo website](https://repo.pbis.beyondtrust.com/).
+You can access the x86_64 RPMs directly, for example: (https://repo.pbis.beyondtrust.com/yum/pbiso/x86_64/Packages/)
 
 ### Using Puppet's built-in fileserver
 


### PR DESCRIPTION
1) Support for PBIS Public repo, including automatic detection of repo file.
2) Support for PBIS Enterprise and Open both (change param in manifests/params.pp)
3) Clean up use around the "config" tool, since the "clean_ad_cache" was unneccessary.